### PR TITLE
Use DefaultKubeVersion for .Capabilities rendering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.19.0+incompatible // indirect
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
-	github.com/bradleyjkemp/cupaloy/v2 v2.4.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,8 @@ github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITg
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.19.0+incompatible h1:xTFLLXzR0JJGQe7M492jAOJ9F3jpYdNiWcL8h9JOV8Y=
 github.com/Masterminds/sprig v2.19.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
-github.com/bradleyjkemp/cupaloy v1.3.0 h1:UJ0YJuhkMXEQcaoQNSCmK8og6GEVW/eDhAZuizvcpOY=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible h1:UafIjBvWQmS9i/xRg+CamMrnLTKNzo+bdmT/oH34c2Y=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible/go.mod h1:Au1Xw1sgaJ5iSFktEhYsS0dbQiS1B0/XMXl+42y9Ilk=
-github.com/bradleyjkemp/cupaloy/v2 v2.4.0/go.mod h1:TD5UU0rdYTbu/TtuwFuWrtiRARuN7mtRipvs/bsShSE=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -48,7 +46,6 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=

--- a/unittest/test_job.go
+++ b/unittest/test_job.go
@@ -166,15 +166,12 @@ func (t *TestJob) releaseOption() *chartutil.ReleaseOptions {
 }
 
 // get chartutil.CapabilityOptions ready for render
-// Only supports APIVersions for now
+// Only supports APIVersions, KubeVersion for now
 func (t *TestJob) capabilityOption() *chartutil.Capabilities {
-	options := chartutil.Capabilities{APIVersions: chartutil.DefaultVersionSet}
-	if len(t.Capabilities.APIVersions) > 0 {
-		var arr []string
-		arr = append(t.Capabilities.APIVersions, "v1")
-		options.APIVersions = chartutil.NewVersionSet(arr...)
+	return &chartutil.Capabilities{
+		APIVersions: chartutil.DefaultVersionSet,
+		KubeVersion: chartutil.DefaultKubeVersion,
 	}
-	return &options
 }
 
 // parse rendered manifest if it's yaml


### PR DESCRIPTION
This will helps to render Helm charts which require `prometheus-operator`, etc that uses `.Capabilities.KubeVersion` object.

Current output:
```
### Chart [ CHART-NAME ] .

 FAIL  test external secret	tests/secret_test.yaml
	- has correct secret name
		Error: render error in "CHART-NAME/charts/prometheus-operator/templates/prometheus/rules/prometheus.rules.yaml": template: CHART-NAME/charts/prometheus-operator/templates/prometheus/rules/prometheus.rules.yaml:6:47: executing "CHART-NAME/charts/prometheus-operator/templates/prometheus/rules/prometheus.rules.yaml" at <.Capabilities.KubeVersion.GitVersion>: can't evaluate field GitVersion in type *version.Info


Charts:      1 failed, 0 passed, 1 total
Test Suites: 1 failed, 0 passed, 1 total
Tests:       1 failed, 1 errored, 0 passed, 1 total
Snapshot:    0 passed, 0 total
Time:        75.078929ms
```

Fixed output:
```
### Chart [ CHART-NAME ] .

 PASS  test external secret	tests/secret_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshot:    0 passed, 0 total
Time:        89.326054ms
```